### PR TITLE
Extra directory up

### DIFF
--- a/maintenance/rebuildTitleKeys.php
+++ b/maintenance/rebuildTitleKeys.php
@@ -2,7 +2,7 @@
 
 $IP = getenv( 'MW_INSTALL_PATH' );
 if ( $IP === false ) {
-	$IP = __DIR__ . '/../..';
+	$IP = __DIR__ . '/../../..';
 }
 require_once "$IP/maintenance/Maintenance.php";
 


### PR DESCRIPTION
in https://github.com/wikimedia/mediawiki-extensions-TitleKey/commit/462b541b2c224a23b8473381e8d4836534eb76cd this file was moved down a directory, which breaks the setting of $IP on line 5